### PR TITLE
[NAV-1382][Departures][Rennes] Set the last stop point ID as the destination

### DIFF
--- a/internal/departures/rennes/rennes.go
+++ b/internal/departures/rennes/rennes.go
@@ -70,9 +70,15 @@ func (d *RennesContext) getConnector() *connectors.Connector {
 }
 
 func (d *RennesContext) setConnector(connector *connectors.Connector) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	d.connector = connector
+}
+
+func (d *RennesContext) getDepartures() map[string]Departure {
 	d.mutex.RLock()
 	defer d.mutex.RUnlock()
-	d.connector = connector
+	return d.departures
 }
 
 func (d *RennesContext) setDepartures(departures map[string]Departure) {
@@ -467,7 +473,7 @@ func loadEstimatedDepartures(rennesContext *RennesContext) (map[string]Departure
 	}
 
 	departuresCopy := make(map[string]Departure, 0)
-	for key, value := range rennesContext.departures {
+	for key, value := range rennesContext.getDepartures() {
 		departuresCopy[key] = value
 	}
 

--- a/internal/departures/rennes/rennes_test.go
+++ b/internal/departures/rennes/rennes_test.go
@@ -55,7 +55,7 @@ func TestLoadTheoreticalDeparturesFromDailyDataFiles(t *testing.T) {
 			StopPointId:      "1412",
 			LineId:           "0801",
 			Direction:        departures.DirectionTypeBackward,
-			DestinationId:    "284721153",
+			DestinationId:    "1412",
 			DestinationName:  "Kennedy",
 			Time: time.Date(
 				DAILY_SERVICE_START_TIME.Year(), DAILY_SERVICE_START_TIME.Month(), DAILY_SERVICE_START_TIME.Day(),

--- a/internal/departures/rennes/routestoppoints/routestoppoints.go
+++ b/internal/departures/rennes/routestoppoints/routestoppoints.go
@@ -3,6 +3,7 @@ package routestoppoints
 import (
 	"fmt"
 	"net/url"
+	"sort"
 	"strconv"
 	"time"
 
@@ -17,10 +18,10 @@ const routeStopPointsCsvNumOfFields int = 4
 // Structure and Consumer to creates RouteStopPoint objects based on a line read from a CSV
 ----------------------------------------------------------------------------------- */
 type RouteStopPoint struct {
-	Id             string
-	StopPointId    string
-	RouteId        string
-	StopPointOrder int
+	Id                  string
+	StopPointInternalId string
+	RouteId             string
+	StopPointOrder      int
 }
 
 func newRouteStopPoint(record []string) (*RouteStopPoint, error) {
@@ -34,10 +35,10 @@ func newRouteStopPoint(record []string) (*RouteStopPoint, error) {
 	}
 
 	return &RouteStopPoint{
-		Id:             record[0],
-		StopPointId:    record[1],
-		RouteId:        record[2],
-		StopPointOrder: stopPointOrder,
+		Id:                  record[0],
+		StopPointInternalId: record[1],
+		RouteId:             record[2],
+		StopPointOrder:      stopPointOrder,
 	}, nil
 }
 
@@ -84,4 +85,41 @@ func LoadRouteStopPoints(uri url.URL, connectionTimeout time.Duration) (map[stri
 		return nil, err
 	}
 	return routeStopPointsConsumer.routeStopPoints, nil
+}
+
+// Sort stop point following their order in the route
+func SortRouteStopPointsByOrder(routeStopPoints map[string]RouteStopPoint) map[string][]RouteStopPoint {
+	unsorted := make(map[string][]RouteStopPoint)
+	for _, routeStopPoint := range routeStopPoints {
+		routeId := routeStopPoint.RouteId
+		if _, ok := unsorted[routeId]; !ok {
+			unsorted[routeId] = make([]RouteStopPoint, 0)
+		}
+		unsorted[routeId] = append(unsorted[routeId], routeStopPoint)
+	}
+	// sort all lists of route stop points following their order
+	for _, routeStopPointList := range unsorted {
+		sort.SliceStable(routeStopPointList, func(i, j int) bool {
+			return routeStopPointList[i].StopPointOrder < routeStopPointList[j].StopPointOrder
+		})
+	}
+	return unsorted
+}
+
+func GetLastStopPointInternalId(
+	sortedRouteStopPoints map[string][]RouteStopPoint,
+	routeId string,
+) (string, error) {
+	err := fmt.Errorf("route id not found: %s", routeId)
+	if sortedRouteStopPointsList, ok := sortedRouteStopPoints[routeId]; ok {
+		if sortedRouteStopPointsList == nil {
+			return "", err
+		}
+		numberOfStopPoints := len(sortedRouteStopPointsList)
+		if numberOfStopPoints == 0 {
+			return "", err
+		}
+		return sortedRouteStopPointsList[numberOfStopPoints-1].StopPointInternalId, nil
+	}
+	return "", err
 }

--- a/internal/departures/rennes/routestoppoints/routestoppoints_test.go
+++ b/internal/departures/rennes/routestoppoints/routestoppoints_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var fixtureDir string
@@ -30,18 +29,17 @@ func TestLoadRouteStopPoints(t *testing.T) {
 	const EXPECTED_NUM_OF_ROUTE_STOP_POINTS int = 12_508
 
 	assert := assert.New(t)
-	require := require.New(t)
 	uri, err := url.Parse(fmt.Sprintf("file://%s/data_rennes/referential", fixtureDir))
-	require.Nil(err)
+	assert.Nil(err)
 
 	loadedRoutesStopPoints, err := LoadRouteStopPoints(*uri, defaultTimeout)
-	require.Nil(err)
+	assert.Nil(err)
 	assert.Len(loadedRoutesStopPoints, EXPECTED_NUM_OF_ROUTE_STOP_POINTS)
 
 	// Check the values read from the first line of the CSV
 	{
 		const EXPECTED_ID string = "284722693"
-		const EXPECTED_STOP_POINT_ID string = "1412"
+		const EXPECTED_STOP_POINT_INTERNAL_ID string = "1412"
 		const EXPECTED_ROUTES_ID string = "284722688"
 		const EXPECTED_STOP_POINT_ORDER int = 4251
 
@@ -49,10 +47,10 @@ func TestLoadRouteStopPoints(t *testing.T) {
 		assert.Equal(
 			loadedRoutesStopPoints[EXPECTED_ID],
 			RouteStopPoint{
-				Id:             EXPECTED_ID,
-				StopPointId:    EXPECTED_STOP_POINT_ID,
-				RouteId:        EXPECTED_ROUTES_ID,
-				StopPointOrder: EXPECTED_STOP_POINT_ORDER,
+				Id:                  EXPECTED_ID,
+				StopPointInternalId: EXPECTED_STOP_POINT_INTERNAL_ID,
+				RouteId:             EXPECTED_ROUTES_ID,
+				StopPointOrder:      EXPECTED_STOP_POINT_ORDER,
 			},
 		)
 	}
@@ -60,7 +58,7 @@ func TestLoadRouteStopPoints(t *testing.T) {
 	// Check the values read from the last line of the CSV
 	{
 		const EXPECTED_ID string = "268501249"
-		const EXPECTED_STOP_POINT_ID string = "1004"
+		const EXPECTED_STOP_POINT_INTERNAL_ID string = "1004"
 		const EXPECTED_ROUTES_ID string = "268501248"
 		const EXPECTED_STOP_POINT_ORDER int = 0
 
@@ -68,12 +66,64 @@ func TestLoadRouteStopPoints(t *testing.T) {
 		assert.Equal(
 			loadedRoutesStopPoints[EXPECTED_ID],
 			RouteStopPoint{
-				Id:             EXPECTED_ID,
-				StopPointId:    EXPECTED_STOP_POINT_ID,
-				RouteId:        EXPECTED_ROUTES_ID,
-				StopPointOrder: EXPECTED_STOP_POINT_ORDER,
+				Id:                  EXPECTED_ID,
+				StopPointInternalId: EXPECTED_STOP_POINT_INTERNAL_ID,
+				RouteId:             EXPECTED_ROUTES_ID,
+				StopPointOrder:      EXPECTED_STOP_POINT_ORDER,
 			},
 		)
 	}
+
+}
+
+func TestSortRouteStopPointsByOrder(t *testing.T) {
+
+	const EXPECTED_NUM_OF_ROUTES int = 1811
+	const UNEXPECTED_ROUTE_ID string = "123456789"
+	const EXPECTED_ROUTE_ID string = "284721408"
+	const EXPECTED_NUM_OF_STOP_POINTS int = 14
+	EXPECTED_STOP_POINTS_ORDER := []int{
+		0,
+		764,
+		1734,
+		2394,
+		2960,
+		3060,
+		3455,
+		3555,
+		4087,
+		4589,
+		5279,
+		7796,
+		8476,
+		8840,
+	}
+
+	assert := assert.New(t)
+	uri, err := url.Parse(fmt.Sprintf("file://%s/data_rennes/referential", fixtureDir))
+	assert.Nil(err)
+
+	unsortedRouteStopPoints, err := LoadRouteStopPoints(*uri, defaultTimeout)
+	assert.Nil(err)
+
+	sortedRouteStopPoints := SortRouteStopPointsByOrder(unsortedRouteStopPoints)
+	assert.Len(sortedRouteStopPoints, EXPECTED_NUM_OF_ROUTES)
+	assert.Contains(sortedRouteStopPoints, EXPECTED_ROUTE_ID)
+	assert.NotContains(sortedRouteStopPoints, UNEXPECTED_ROUTE_ID)
+
+	sortedRouteStopPointsList := sortedRouteStopPoints[EXPECTED_ROUTE_ID]
+	assert.Len(sortedRouteStopPointsList, EXPECTED_NUM_OF_STOP_POINTS)
+
+	gotStopPointsOrder := make([]int, 0, EXPECTED_NUM_OF_STOP_POINTS)
+	for _, routeStopPoint := range sortedRouteStopPointsList {
+		gotStopPointsOrder = append(
+			gotStopPointsOrder,
+			routeStopPoint.StopPointOrder,
+		)
+	}
+	assert.Equal(
+		EXPECTED_STOP_POINTS_ORDER,
+		gotStopPointsOrder,
+	)
 
 }


### PR DESCRIPTION
Set the last stop point ID as the destination for the API `/departures` of the connector `rennes`.