### PR TITLE
[Departures] Query: increase the expected values for the param `departure_type`

### DIFF
--- a/internal/departures/data.go
+++ b/internal/departures/data.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -69,10 +70,11 @@ func ParseDirectionType(value string) DirectionType {
 }
 
 func ParseDirectionTypeFromNavitia(value string) (DirectionType, error) {
-	switch value {
-	case "forward":
+	lowerCaseValue := strings.ToLower(value)
+	switch lowerCaseValue {
+	case "forward", "outbound":
 		return DirectionTypeForward, nil
-	case "backward":
+	case "backward", "inbound":
 		return DirectionTypeBackward, nil
 	case "", "both":
 		return DirectionTypeBoth, nil
@@ -80,7 +82,6 @@ func ParseDirectionTypeFromNavitia(value string) (DirectionType, error) {
 		return DirectionTypeUnknown, nil
 	default:
 		return DirectionTypeUnknown, fmt.Errorf("impossible to parse %s", value)
-
 	}
 }
 

--- a/internal/departures/data_test.go
+++ b/internal/departures/data_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,5 +15,104 @@ func TestDepartureTypeString(t *testing.T) {
 	}
 	{
 		require.Equal(fmt.Sprint(DepartureTypeEstimated), "E")
+	}
+}
+
+func TestParseDirectionTypeFromNavitia(t *testing.T) {
+	assert := assert.New(t)
+
+	var tests = []struct {
+		directionTypeStr string
+		errorIsExpected  bool
+		expectedResult   DirectionType
+	}{
+		{
+			directionTypeStr: "FORWARD",
+			errorIsExpected:  false,
+			expectedResult:   DirectionTypeForward,
+		},
+		{
+			directionTypeStr: "Forward",
+			errorIsExpected:  false,
+			expectedResult:   DirectionTypeForward,
+		},
+		{
+			directionTypeStr: "forward",
+			errorIsExpected:  false,
+			expectedResult:   DirectionTypeForward,
+		},
+		{
+			directionTypeStr: "BACKWARD",
+			errorIsExpected:  false,
+			expectedResult:   DirectionTypeBackward,
+		},
+		{
+			directionTypeStr: "Backward",
+			errorIsExpected:  false,
+			expectedResult:   DirectionTypeBackward,
+		},
+		{
+			directionTypeStr: "backward",
+			errorIsExpected:  false,
+			expectedResult:   DirectionTypeBackward,
+		},
+		{
+			directionTypeStr: "OUTBOUND",
+			errorIsExpected:  false,
+			expectedResult:   DirectionTypeForward,
+		},
+		{
+			directionTypeStr: "Outbound",
+			errorIsExpected:  false,
+			expectedResult:   DirectionTypeForward,
+		},
+		{
+			directionTypeStr: "outbound",
+			errorIsExpected:  false,
+			expectedResult:   DirectionTypeForward,
+		},
+		{
+			directionTypeStr: "INBOUND",
+			errorIsExpected:  false,
+			expectedResult:   DirectionTypeBackward,
+		},
+		{
+			directionTypeStr: "Inbound",
+			errorIsExpected:  false,
+			expectedResult:   DirectionTypeBackward,
+		},
+		{
+			directionTypeStr: "inbound",
+			errorIsExpected:  false,
+			expectedResult:   DirectionTypeBackward,
+		},
+		{
+			directionTypeStr: "",
+			errorIsExpected:  false,
+			expectedResult:   DirectionTypeBoth,
+		},
+		{
+			directionTypeStr: "foo",
+			errorIsExpected:  true,
+			expectedResult:   DirectionTypeUnknown,
+		},
+		{
+			directionTypeStr: "ALL",
+			errorIsExpected:  true,
+			expectedResult:   DirectionTypeUnknown,
+		},
+	}
+
+	for _, test := range tests {
+		getResult, err := ParseDirectionTypeFromNavitia(test.directionTypeStr)
+		if test.errorIsExpected {
+			assert.NotNil(err)
+		} else {
+			assert.Nil(err)
+			assert.Equal(
+				test.expectedResult,
+				getResult,
+			)
+		}
 	}
 }

--- a/internal/departures/sytralrt/sytraltr_test.go
+++ b/internal/departures/sytralrt/sytraltr_test.go
@@ -125,7 +125,14 @@ func TestDeparturesApi(t *testing.T) {
 			assert.Empty(response.Message)
 			require.NotNil(response.Departures)
 			assert.NotEmpty(response.Departures)
-			assert.Len(*response.Departures, 8)
+			const EXPECTED_NUMBER_OF_DEPARTURES int = 8
+			assert.Len(*response.Departures, EXPECTED_NUMBER_OF_DEPARTURES)
+			for _, departure := range *response.Departures {
+				require.True(
+					departure.DirectionType == departures.DirectionTypeForward ||
+						departure.DirectionType == departures.DirectionTypeBackward,
+				)
+			}
 		}
 
 		{
@@ -140,7 +147,14 @@ func TestDeparturesApi(t *testing.T) {
 			assert.Empty(response.Message)
 			require.NotNil(response.Departures)
 			assert.NotEmpty(response.Departures)
-			assert.Len(*response.Departures, 8)
+			const EXPECTED_NUMBER_OF_DEPARTURES int = 8
+			assert.Len(*response.Departures, EXPECTED_NUMBER_OF_DEPARTURES)
+			for _, departure := range *response.Departures {
+				require.True(
+					departure.DirectionType == departures.DirectionTypeForward ||
+						departure.DirectionType == departures.DirectionTypeBackward,
+				)
+			}
 		}
 
 		{
@@ -155,7 +169,36 @@ func TestDeparturesApi(t *testing.T) {
 			assert.Empty(response.Message)
 			require.NotNil(response.Departures)
 			assert.NotEmpty(response.Departures)
-			assert.Len(*response.Departures, 4)
+			const EXPECTED_NUMBER_OF_DEPARTURES int = 4
+			assert.Len(*response.Departures, EXPECTED_NUMBER_OF_DEPARTURES)
+			for _, departure := range *response.Departures {
+				require.Equal(
+					departures.DirectionTypeForward,
+					departure.DirectionType,
+				)
+			}
+		}
+
+		{
+			c.Request = httptest.NewRequest("GET", "/departures?stop_id=3&stop_id=4&direction_type=outbound", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, c.Request)
+			require.Equal(200, w.Code)
+
+			response := departures.DeparturesResponse{}
+			err := json.Unmarshal(w.Body.Bytes(), &response)
+			require.Nil(err)
+			assert.Empty(response.Message)
+			require.NotNil(response.Departures)
+			assert.NotEmpty(response.Departures)
+			const EXPECTED_NUMBER_OF_DEPARTURES int = 4
+			assert.Len(*response.Departures, EXPECTED_NUMBER_OF_DEPARTURES)
+			for _, departure := range *response.Departures {
+				require.Equal(
+					departures.DirectionTypeForward,
+					departure.DirectionType,
+				)
+			}
 		}
 
 		{
@@ -170,7 +213,36 @@ func TestDeparturesApi(t *testing.T) {
 			assert.Empty(response.Message)
 			require.NotNil(response.Departures)
 			assert.NotEmpty(response.Departures)
-			assert.Len(*response.Departures, 2)
+			const EXPECTED_NUMBER_OF_DEPARTURES int = 2
+			assert.Len(*response.Departures, EXPECTED_NUMBER_OF_DEPARTURES)
+			for _, departure := range *response.Departures {
+				require.Equal(
+					departures.DirectionTypeBackward,
+					departure.DirectionType,
+				)
+			}
+		}
+
+		{
+			c.Request = httptest.NewRequest("GET", "/departures?stop_id=3&direction_type=inbound", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, c.Request)
+			require.Equal(200, w.Code)
+
+			response := departures.DeparturesResponse{}
+			err := json.Unmarshal(w.Body.Bytes(), &response)
+			require.Nil(err)
+			assert.Empty(response.Message)
+			require.NotNil(response.Departures)
+			assert.NotEmpty(response.Departures)
+			const EXPECTED_NUMBER_OF_DEPARTURES int = 2
+			assert.Len(*response.Departures, EXPECTED_NUMBER_OF_DEPARTURES)
+			for _, departure := range *response.Departures {
+				require.Equal(
+					departures.DirectionTypeBackward,
+					departure.DirectionType,
+				)
+			}
 		}
 
 		{
@@ -520,25 +592,4 @@ func TestParseDirectionType(t *testing.T) {
 	assert.Equal(departures.DirectionTypeBackward, departures.ParseDirectionType("RET"))
 	assert.Equal(departures.DirectionTypeUnknown, departures.ParseDirectionType(""))
 	assert.Equal(departures.DirectionTypeUnknown, departures.ParseDirectionType("foo"))
-}
-
-func TestParseDirectionTypeFromNavitia(t *testing.T) {
-	assert := assert.New(t)
-
-	r, err := departures.ParseDirectionTypeFromNavitia("forward")
-	assert.Nil(err)
-	assert.Equal(departures.DirectionTypeForward, r)
-
-	r, err = departures.ParseDirectionTypeFromNavitia("backward")
-	assert.Nil(err)
-	assert.Equal(departures.DirectionTypeBackward, r)
-
-	r, err = departures.ParseDirectionTypeFromNavitia("")
-	assert.Nil(err)
-	assert.Equal(departures.DirectionTypeBoth, r)
-
-	_, err = departures.ParseDirectionTypeFromNavitia("foo")
-	assert.NotNil(err)
-	_, err = departures.ParseDirectionTypeFromNavitia("ALL")
-	assert.NotNil(err)
 }

--- a/internal/departures/sytralrt/sytraltr_test.go
+++ b/internal/departures/sytralrt/sytraltr_test.go
@@ -125,8 +125,7 @@ func TestDeparturesApi(t *testing.T) {
 			assert.Empty(response.Message)
 			require.NotNil(response.Departures)
 			assert.NotEmpty(response.Departures)
-			const EXPECTED_NUMBER_OF_DEPARTURES int = 8
-			assert.Len(*response.Departures, EXPECTED_NUMBER_OF_DEPARTURES)
+			assert.Len(*response.Departures, 8)
 			for _, departure := range *response.Departures {
 				require.True(
 					departure.DirectionType == departures.DirectionTypeForward ||
@@ -147,8 +146,7 @@ func TestDeparturesApi(t *testing.T) {
 			assert.Empty(response.Message)
 			require.NotNil(response.Departures)
 			assert.NotEmpty(response.Departures)
-			const EXPECTED_NUMBER_OF_DEPARTURES int = 8
-			assert.Len(*response.Departures, EXPECTED_NUMBER_OF_DEPARTURES)
+			assert.Len(*response.Departures, 8)
 			for _, departure := range *response.Departures {
 				require.True(
 					departure.DirectionType == departures.DirectionTypeForward ||
@@ -169,8 +167,7 @@ func TestDeparturesApi(t *testing.T) {
 			assert.Empty(response.Message)
 			require.NotNil(response.Departures)
 			assert.NotEmpty(response.Departures)
-			const EXPECTED_NUMBER_OF_DEPARTURES int = 4
-			assert.Len(*response.Departures, EXPECTED_NUMBER_OF_DEPARTURES)
+			assert.Len(*response.Departures, 4)
 			for _, departure := range *response.Departures {
 				require.Equal(
 					departures.DirectionTypeForward,
@@ -191,8 +188,7 @@ func TestDeparturesApi(t *testing.T) {
 			assert.Empty(response.Message)
 			require.NotNil(response.Departures)
 			assert.NotEmpty(response.Departures)
-			const EXPECTED_NUMBER_OF_DEPARTURES int = 4
-			assert.Len(*response.Departures, EXPECTED_NUMBER_OF_DEPARTURES)
+			assert.Len(*response.Departures, 4)
 			for _, departure := range *response.Departures {
 				require.Equal(
 					departures.DirectionTypeForward,
@@ -213,8 +209,7 @@ func TestDeparturesApi(t *testing.T) {
 			assert.Empty(response.Message)
 			require.NotNil(response.Departures)
 			assert.NotEmpty(response.Departures)
-			const EXPECTED_NUMBER_OF_DEPARTURES int = 2
-			assert.Len(*response.Departures, EXPECTED_NUMBER_OF_DEPARTURES)
+			assert.Len(*response.Departures, 2)
 			for _, departure := range *response.Departures {
 				require.Equal(
 					departures.DirectionTypeBackward,
@@ -235,8 +230,7 @@ func TestDeparturesApi(t *testing.T) {
 			assert.Empty(response.Message)
 			require.NotNil(response.Departures)
 			assert.NotEmpty(response.Departures)
-			const EXPECTED_NUMBER_OF_DEPARTURES int = 2
-			assert.Len(*response.Departures, EXPECTED_NUMBER_OF_DEPARTURES)
+			assert.Len(*response.Departures, 2)
 			for _, departure := range *response.Departures {
 				require.Equal(
 					departures.DirectionTypeBackward,


### PR DESCRIPTION
- Add `inbound` and `outbound` as expected values
- All values are case insensitive