### PR TITLE
[SIRI-SM] XML Notification: Make the tag `<ExpectedDepartureTime>` as optional

### DIFF
--- a/internal/departures/sirism/sirism.go
+++ b/internal/departures/sirism/sirism.go
@@ -257,14 +257,10 @@ func mapDeparturesByStopPointId(
 ) map[string][]departures.Departure {
 	result := make(map[string][]departures.Departure)
 	for _, siriSmDeparture := range siriSmDepartures {
-		departureType := departures.DepartureTypeEstimated
-		if siriSmDeparture.DepartureTimeIsTheoretical() {
-			departureType = departures.DepartureTypeTheoretical
-		}
 		appendedDeparture := departures.Departure{
 			Line:          siriSmDeparture.LineRef,
 			Stop:          string(siriSmDeparture.StopPointRef),
-			Type:          fmt.Sprint(departureType),
+			Type:          fmt.Sprint(siriSmDeparture.GetDepartureType()),
 			Direction:     siriSmDeparture.DestinationRef,
 			DirectionName: siriSmDeparture.DestinationName,
 			Datetime:      siriSmDeparture.GetDepartureTime(),

--- a/internal/departures/sytralrt/sytraltr_test.go
+++ b/internal/departures/sytralrt/sytraltr_test.go
@@ -100,12 +100,18 @@ func TestDeparturesApi(t *testing.T) {
 		{
 			requestUri:                 "/departures?stop_id=3&stop_id=4",
 			expectedNumberOfDepartures: 8,
-			getDeparturesList:          []departures.DirectionType{departures.DirectionTypeForward, departures.DirectionTypeBackward},
+			getDeparturesList: []departures.DirectionType{
+				departures.DirectionTypeForward,
+				departures.DirectionTypeBackward,
+			},
 		},
 		{
 			requestUri:                 "/departures?stop_id=3&stop_id=4&direction_type=both",
 			expectedNumberOfDepartures: 8,
-			getDeparturesList:          []departures.DirectionType{departures.DirectionTypeForward, departures.DirectionTypeBackward},
+			getDeparturesList: []departures.DirectionType{
+				departures.DirectionTypeForward,
+				departures.DirectionTypeBackward,
+			},
 		},
 		{
 			requestUri:                 "/departures?stop_id=3&stop_id=4&direction_type=forward",

--- a/internal/sirism/xml/xml.go
+++ b/internal/sirism/xml/xml.go
@@ -118,7 +118,7 @@ type MonitoredCall struct {
 	XMLName               xml.Name     `xml:"MonitoredCall"`
 	StopPointRef          StopPointRef `xml:"StopPointRef"`
 	AimedDepartureTime    customTime   `xml:"AimedDepartureTime"`
-	ExpectedDepartureTime customTime   `xml:"ExpectedDepartureTime"`
+	ExpectedDepartureTime *customTime  `xml:"ExpectedDepartureTime,omitempty"`
 }
 
 type customTime time.Time


### PR DESCRIPTION
The XML `<ExpectedDepartureTime>` is optional,

If the tag is present the departure is estimated otherwise it is theoretical.