### PR TITLE
Add departures in status with some attributes added in all objects

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -92,7 +92,8 @@ func TestStatusApiHasLastUpdateTime(t *testing.T) {
 	assert.True(response.Departures.LastUpdate.Before(time.Now()))
 	assert.Equal(response.Departures.Source, "sytralrt")
 	assert.Equal(response.Departures.SourceStatus, "ok")
-	assert.Equal(response.Departures.LastStatusUpdate, time.Time{})
+	assert.True(response.Departures.LastStatusUpdate.After(startTime))
+	assert.True(response.Departures.LastStatusUpdate.Before(time.Now()))
 	assert.Equal(response.Departures.Message, "")
 }
 
@@ -250,8 +251,8 @@ func TestVehicleOccupanciesAPIWithDataFromFile(t *testing.T) {
 	// Verify additional attributes in /status
 	assert.Equal(status.VehicleOccupancies.Source, "oditi")
 	assert.Equal(status.VehicleOccupancies.SourceStatus, "ok")
-	// LastStatusUpdate never updated
-	assert.Equal(status.VehicleOccupancies.LastStatusUpdate, time.Time{})
+	assert.True(status.VehicleOccupancies.LastStatusUpdate.After(startTime))
+	assert.True(status.VehicleOccupancies.LastStatusUpdate.Before(time.Now()))
 	// Empty message
 	assert.Equal(status.VehicleOccupancies.Message, "")
 }
@@ -316,8 +317,8 @@ func TestStatusInFreeFloatingWithDataFromFile(t *testing.T) {
 	// Verify additional attributes in /status
 	assert.Equal(response.FreeFloatings.Source, "fluctuo")
 	assert.Equal(response.FreeFloatings.SourceStatus, "ok")
-	// LastStatusUpdate never updated
-	assert.Equal(response.FreeFloatings.LastStatusUpdate, time.Time{})
+	assert.True(response.FreeFloatings.LastStatusUpdate.After(startTime))
+	assert.True(response.FreeFloatings.LastStatusUpdate.Before(time.Now()))
 	// Empty message
 	assert.Equal(response.FreeFloatings.Message, "")
 }

--- a/cmd/forseti/main.go
+++ b/cmd/forseti/main.go
@@ -330,7 +330,7 @@ func FreeFloating(manager *manager.DataManager, config *Config, router *gin.Engi
 
 	freeFloatingsContext := &freefloatings.FreeFloatingsContext{}
 	manager.SetFreeFloatingsContext(freeFloatingsContext)
-	freeFloatingsContext.SetStatus("init")
+	go freeFloatingsContext.SetStatus("init")
 	freefloatings.AddFreeFloatingsEntryPoint(router, freeFloatingsContext)
 	freeFloatingsContext.ManageFreeFloatingsStatus(config.FreeFloatingsActive)
 
@@ -370,7 +370,7 @@ func Departures(
 	manager.SetDeparturesContext(departuresContext)
 	departures.AddDeparturesEntryPoint(router, departuresContext)
 	departuresContext.SetConnectorType(config.DeparturesType)
-	departuresContext.SetStatus("init")
+	go departuresContext.SetStatus("init")
 
 	// Enable the SytralRT connector
 	if config.DeparturesType == string(connectors.Connector_SYTRALRT) {

--- a/cmd/forseti/main.go
+++ b/cmd/forseti/main.go
@@ -330,7 +330,7 @@ func FreeFloating(manager *manager.DataManager, config *Config, router *gin.Engi
 
 	freeFloatingsContext := &freefloatings.FreeFloatingsContext{}
 	manager.SetFreeFloatingsContext(freeFloatingsContext)
-	freeFloatingsContext.SetStatus("ok")
+	freeFloatingsContext.SetStatus("init")
 	freefloatings.AddFreeFloatingsEntryPoint(router, freeFloatingsContext)
 	freeFloatingsContext.ManageFreeFloatingsStatus(config.FreeFloatingsActive)
 
@@ -370,7 +370,7 @@ func Departures(
 	manager.SetDeparturesContext(departuresContext)
 	departures.AddDeparturesEntryPoint(router, departuresContext)
 	departuresContext.SetConnectorType(config.DeparturesType)
-	departuresContext.SetStatus("ok")
+	departuresContext.SetStatus("init")
 
 	// Enable the SytralRT connector
 	if config.DeparturesType == string(connectors.Connector_SYTRALRT) {
@@ -430,7 +430,7 @@ func VehicleOccupancies(manager *manager.DataManager, config *Config, router *gi
 			logrus.Error(err)
 			return
 		}
-		vehicleOccupanciesOditiContext.SetStatus("ok")
+		vehicleOccupanciesOditiContext.SetStatus("init")
 		manager.SetVehicleOccupanciesContext(vehicleOccupanciesOditiContext)
 
 		vehicleOccupanciesOditiContext.InitContext(config.OccupancyFilesURI, config.OccupancyServiceURI,
@@ -500,7 +500,7 @@ func VehiclePositions(
 		return
 	}
 
-	vehiclePositionsContext.SetStatus("ok")
+	vehiclePositionsContext.SetStatus("init")
 	manager.SetVehiclePositionsContext(vehiclePositionsContext)
 
 	vehiclePositionsContext.InitContext(

--- a/cmd/forseti/main.go
+++ b/cmd/forseti/main.go
@@ -330,6 +330,7 @@ func FreeFloating(manager *manager.DataManager, config *Config, router *gin.Engi
 
 	freeFloatingsContext := &freefloatings.FreeFloatingsContext{}
 	manager.SetFreeFloatingsContext(freeFloatingsContext)
+	freeFloatingsContext.SetStatus("ok")
 	freefloatings.AddFreeFloatingsEntryPoint(router, freeFloatingsContext)
 	freeFloatingsContext.ManageFreeFloatingsStatus(config.FreeFloatingsActive)
 
@@ -368,10 +369,11 @@ func Departures(
 	departuresContext := &departures.DeparturesContext{}
 	manager.SetDeparturesContext(departuresContext)
 	departures.AddDeparturesEntryPoint(router, departuresContext)
+	departuresContext.SetConnectorType(config.DeparturesType)
+	departuresContext.SetStatus("ok")
 
 	// Enable the SytralRT connector
 	if config.DeparturesType == string(connectors.Connector_SYTRALRT) {
-
 		var sytralContext sytralrt.SytralRTContext = sytralrt.SytralRTContext{}
 		sytralContext.InitContext(config.DeparturesFilesURI, config.DeparturesFilesRefresh, config.ConnectionTimeout)
 		go sytralContext.RefreshDeparturesLoop(departuresContext)
@@ -428,6 +430,7 @@ func VehicleOccupancies(manager *manager.DataManager, config *Config, router *gi
 			logrus.Error(err)
 			return
 		}
+		vehicleOccupanciesOditiContext.SetStatus("ok")
 		manager.SetVehicleOccupanciesContext(vehicleOccupanciesOditiContext)
 
 		vehicleOccupanciesOditiContext.InitContext(config.OccupancyFilesURI, config.OccupancyServiceURI,
@@ -497,6 +500,7 @@ func VehiclePositions(
 		return
 	}
 
+	vehiclePositionsContext.SetStatus("ok")
 	manager.SetVehiclePositionsContext(vehiclePositionsContext)
 
 	vehiclePositionsContext.InitContext(

--- a/cmd/forseti/main.go
+++ b/cmd/forseti/main.go
@@ -430,7 +430,7 @@ func VehicleOccupancies(manager *manager.DataManager, config *Config, router *gi
 			logrus.Error(err)
 			return
 		}
-		vehicleOccupanciesOditiContext.SetStatus("init")
+		go vehicleOccupanciesOditiContext.SetStatus("init")
 		manager.SetVehicleOccupanciesContext(vehicleOccupanciesOditiContext)
 
 		vehicleOccupanciesOditiContext.InitContext(config.OccupancyFilesURI, config.OccupancyServiceURI,
@@ -453,7 +453,7 @@ func VehicleOccupancies(manager *manager.DataManager, config *Config, router *gi
 		}
 
 		manager.SetVehicleOccupanciesContext(vehicleOccupanciesContext)
-
+		go vehicleOccupanciesContext.SetStatus("init")
 		vehicleOccupanciesContext.InitContext(config.OccupancyFilesURI, config.OccupancyServiceURI,
 			config.OccupancyServiceToken, config.OccupancyNavitiaURI, config.OccupancyNavitiaToken,
 			config.OccupancyRefresh, config.OccupancyCleanVJ, config.OccupancyCleanVO, config.ConnectionTimeout,
@@ -500,10 +500,11 @@ func VehiclePositions(
 		return
 	}
 
-	vehiclePositionsContext.SetStatus("init")
+	go vehiclePositionsContext.SetStatus("init")
 	manager.SetVehiclePositionsContext(vehiclePositionsContext)
 
 	vehiclePositionsContext.InitContext(
+
 		config.PositionsFilesURI,
 		config.PositionsFilesRefresh,
 		config.PositionsServiceURI,

--- a/cmd/forseti/main.go
+++ b/cmd/forseti/main.go
@@ -330,7 +330,7 @@ func FreeFloating(manager *manager.DataManager, config *Config, router *gin.Engi
 
 	freeFloatingsContext := &freefloatings.FreeFloatingsContext{}
 	manager.SetFreeFloatingsContext(freeFloatingsContext)
-	go freeFloatingsContext.SetStatus("init")
+	freeFloatingsContext.SetStatus("init")
 	freefloatings.AddFreeFloatingsEntryPoint(router, freeFloatingsContext)
 	freeFloatingsContext.ManageFreeFloatingsStatus(config.FreeFloatingsActive)
 
@@ -370,7 +370,7 @@ func Departures(
 	manager.SetDeparturesContext(departuresContext)
 	departures.AddDeparturesEntryPoint(router, departuresContext)
 	departuresContext.SetConnectorType(config.DeparturesType)
-	go departuresContext.SetStatus("init")
+	departuresContext.SetStatus("init")
 
 	// Enable the SytralRT connector
 	if config.DeparturesType == string(connectors.Connector_SYTRALRT) {
@@ -430,7 +430,6 @@ func VehicleOccupancies(manager *manager.DataManager, config *Config, router *gi
 			logrus.Error(err)
 			return
 		}
-		go vehicleOccupanciesOditiContext.SetStatus("init")
 		manager.SetVehicleOccupanciesContext(vehicleOccupanciesOditiContext)
 
 		vehicleOccupanciesOditiContext.InitContext(config.OccupancyFilesURI, config.OccupancyServiceURI,
@@ -453,7 +452,6 @@ func VehicleOccupancies(manager *manager.DataManager, config *Config, router *gi
 		}
 
 		manager.SetVehicleOccupanciesContext(vehicleOccupanciesContext)
-		go vehicleOccupanciesContext.SetStatus("init")
 		vehicleOccupanciesContext.InitContext(config.OccupancyFilesURI, config.OccupancyServiceURI,
 			config.OccupancyServiceToken, config.OccupancyNavitiaURI, config.OccupancyNavitiaToken,
 			config.OccupancyRefresh, config.OccupancyCleanVJ, config.OccupancyCleanVO, config.ConnectionTimeout,
@@ -500,7 +498,6 @@ func VehiclePositions(
 		return
 	}
 
-	go vehiclePositionsContext.SetStatus("init")
 	manager.SetVehiclePositionsContext(vehiclePositionsContext)
 
 	vehiclePositionsContext.InitContext(

--- a/internal/departures/context.go
+++ b/internal/departures/context.go
@@ -134,6 +134,7 @@ func (d *DeparturesContext) SetStatus(status string) {
 	d.departuresMutex.Lock()
 	defer d.departuresMutex.Unlock()
 
+	d.lastStatusUpdate = time.Now()
 	d.status = status
 }
 

--- a/internal/departures/context.go
+++ b/internal/departures/context.go
@@ -11,10 +11,13 @@ import (
 type DeparturesContext struct {
 	departures          *map[string][]Departure
 	lastDepartureUpdate time.Time
+	lastStatusUpdate    time.Time
 	departuresMutex     sync.RWMutex
 	packageName         string
 	filesRefreshTime    time.Duration
 	wsRefreshTime       time.Duration
+	connectorType       string
+	status              string
 }
 
 func (d *DeparturesContext) UpdateDepartures(departures map[string][]Departure) {
@@ -35,6 +38,13 @@ func (d *DeparturesContext) GetLastDepartureDataUpdate() time.Time {
 	defer d.departuresMutex.RUnlock()
 
 	return d.lastDepartureUpdate
+}
+
+func (d *DeparturesContext) GetLastStatusUpdate() time.Time {
+	d.departuresMutex.RLock()
+	defer d.departuresMutex.RUnlock()
+
+	return d.lastStatusUpdate
 }
 
 func (d *DeparturesContext) GetDeparturesByStops(stopsID []string) ([]Departure, error) {
@@ -113,6 +123,20 @@ func (d *DeparturesContext) SetWsRefeshTime(wsRefreshTime time.Duration) {
 	d.wsRefreshTime = wsRefreshTime
 }
 
+func (d *DeparturesContext) GetStatus() string {
+	d.departuresMutex.Lock()
+	defer d.departuresMutex.Unlock()
+
+	return d.status
+}
+
+func (d *DeparturesContext) SetStatus(status string) {
+	d.departuresMutex.Lock()
+	defer d.departuresMutex.Unlock()
+
+	d.status = status
+}
+
 func keepDirection(departureDirectionType, wantedDirectionType DirectionType) bool {
 	return (wantedDirectionType == departureDirectionType ||
 		departureDirectionType == DirectionTypeUnknown ||
@@ -128,4 +152,16 @@ func filterDeparturesByDirectionType(departures []Departure, directionType Direc
 		}
 	}
 	return departures[:n]
+}
+
+func (d *DeparturesContext) GetConnectorType() string {
+	d.departuresMutex.RLock()
+	defer d.departuresMutex.RUnlock()
+	return d.connectorType
+}
+
+func (d *DeparturesContext) SetConnectorType(connectorType string) {
+	d.departuresMutex.RLock()
+	defer d.departuresMutex.RUnlock()
+	d.connectorType = connectorType
 }

--- a/internal/freefloatings/context.go
+++ b/internal/freefloatings/context.go
@@ -14,10 +14,12 @@ import (
 type FreeFloatingsContext struct {
 	freeFloatings          *[]FreeFloating
 	lastFreeFloatingUpdate time.Time
+	lastStatusUpdate       time.Time
 	freeFloatingsMutex     sync.RWMutex
 	loadFreeFloatingData   bool
 	packageName            string
 	RefreshTime            time.Duration
+	status                 string
 }
 
 func (d *FreeFloatingsContext) ManageFreeFloatingsStatus(activate bool) {
@@ -48,6 +50,13 @@ func (d *FreeFloatingsContext) GetLastFreeFloatingsDataUpdate() time.Time {
 	return d.lastFreeFloatingUpdate
 }
 
+func (d *FreeFloatingsContext) GetLastStatusUpdate() time.Time {
+	d.freeFloatingsMutex.RLock()
+	defer d.freeFloatingsMutex.RUnlock()
+
+	return d.lastStatusUpdate
+}
+
 func (d *FreeFloatingsContext) GetRereshTime() string {
 	d.freeFloatingsMutex.Lock()
 	defer d.freeFloatingsMutex.Unlock()
@@ -67,6 +76,20 @@ func (d *FreeFloatingsContext) SetPackageName(pathPackage string) {
 	paths := strings.Split(pathPackage, "/")
 	size := len(paths)
 	d.packageName = paths[size-1]
+}
+
+func (d *FreeFloatingsContext) GetStatus() string {
+	d.freeFloatingsMutex.Lock()
+	defer d.freeFloatingsMutex.Unlock()
+
+	return d.status
+}
+
+func (d *FreeFloatingsContext) SetStatus(status string) {
+	d.freeFloatingsMutex.Lock()
+	defer d.freeFloatingsMutex.Unlock()
+
+	d.status = status
 }
 
 //nolint

--- a/internal/freefloatings/context.go
+++ b/internal/freefloatings/context.go
@@ -89,7 +89,7 @@ func (d *FreeFloatingsContext) SetStatus(status string) {
 	d.freeFloatingsMutex.Lock()
 	defer d.freeFloatingsMutex.Unlock()
 
-    d.lastStatusUpdate = time.Now()
+	d.lastStatusUpdate = time.Now()
 	d.status = status
 }
 

--- a/internal/freefloatings/context.go
+++ b/internal/freefloatings/context.go
@@ -89,6 +89,7 @@ func (d *FreeFloatingsContext) SetStatus(status string) {
 	d.freeFloatingsMutex.Lock()
 	defer d.freeFloatingsMutex.Unlock()
 
+    d.lastStatusUpdate = time.Now()
 	d.status = status
 }
 

--- a/internal/vehicleoccupancies/context.go
+++ b/internal/vehicleoccupancies/context.go
@@ -15,9 +15,11 @@ import (
 type VehicleOccupanciesContext struct {
 	VehicleOccupancies           map[string]*VehicleOccupancy
 	lastVehicleOccupanciesUpdate time.Time
+	lastStatusUpdate             time.Time
 	vehicleOccupanciesMutex      sync.RWMutex
 	loadOccupancyData            bool
 	refreshTime                  time.Duration
+	status                       string
 }
 
 func (d *VehicleOccupanciesContext) ManageVehicleOccupancyStatus(activate bool) {
@@ -75,6 +77,13 @@ func (d *VehicleOccupanciesContext) GetLastVehicleOccupanciesDataUpdate() time.T
 	return d.lastVehicleOccupanciesUpdate
 }
 
+func (d *VehicleOccupanciesContext) GetLastStatusUpdate() time.Time {
+	d.vehicleOccupanciesMutex.RLock()
+	defer d.vehicleOccupanciesMutex.RUnlock()
+
+	return d.lastStatusUpdate
+}
+
 func (d *VehicleOccupanciesContext) GetVehiclesOccupancies() (vehicleOccupancies map[string]*VehicleOccupancy) {
 	d.vehicleOccupanciesMutex.RLock()
 	defer d.vehicleOccupanciesMutex.RUnlock()
@@ -127,6 +136,18 @@ func (d *VehicleOccupanciesContext) SetRereshTime(newRefreshTime time.Duration) 
 	d.vehicleOccupanciesMutex.Lock()
 	defer d.vehicleOccupanciesMutex.Unlock()
 	d.refreshTime = newRefreshTime
+}
+
+func (d *VehicleOccupanciesContext) GetStatus() string {
+	d.vehicleOccupanciesMutex.Lock()
+	defer d.vehicleOccupanciesMutex.Unlock()
+	return d.status
+}
+
+func (d *VehicleOccupanciesContext) SetStatus(status string) {
+	d.vehicleOccupanciesMutex.Lock()
+	defer d.vehicleOccupanciesMutex.Unlock()
+	d.status = status
 }
 
 func getKeyVehicleOccupancy() string {

--- a/internal/vehicleoccupancies/context.go
+++ b/internal/vehicleoccupancies/context.go
@@ -147,6 +147,7 @@ func (d *VehicleOccupanciesContext) GetStatus() string {
 func (d *VehicleOccupanciesContext) SetStatus(status string) {
 	d.vehicleOccupanciesMutex.Lock()
 	defer d.vehicleOccupanciesMutex.Unlock()
+	d.lastStatusUpdate = time.Now()
 	d.status = status
 }
 

--- a/internal/vehicleoccupancies/contextGtfsRt.go
+++ b/internal/vehicleoccupancies/contextGtfsRt.go
@@ -79,6 +79,7 @@ func (d *VehicleOccupanciesGtfsRtContext) InitContext(filesURI, externalURI url.
 	d.voContext = &VehicleOccupanciesContext{}
 	d.voContext.ManageVehicleOccupancyStatus(occupancyActive)
 	d.voContext.SetRereshTime(loadExternalRefresh)
+	d.voContext.SetStatus("init")
 }
 
 // main loop to refresh vehicle_occupancies from Gtfs-rt flux

--- a/internal/vehicleoccupancies/contextGtfsRt.go
+++ b/internal/vehicleoccupancies/contextGtfsRt.go
@@ -112,12 +112,28 @@ func (d *VehicleOccupanciesGtfsRtContext) GetLastVehicleOccupanciesDataUpdate() 
 	return d.voContext.GetLastVehicleOccupanciesDataUpdate()
 }
 
+func (d *VehicleOccupanciesGtfsRtContext) GetLastStatusUpdate() time.Time {
+	return d.voContext.GetLastStatusUpdate()
+}
+
 func (d *VehicleOccupanciesGtfsRtContext) LoadOccupancyData() bool {
 	return d.voContext.LoadOccupancyData()
 }
 
 func (d *VehicleOccupanciesGtfsRtContext) GetRereshTime() string {
 	return d.voContext.GetRereshTime()
+}
+
+func (d *VehicleOccupanciesGtfsRtContext) GetStatus() string {
+	return d.voContext.GetStatus()
+}
+
+func (d *VehicleOccupanciesGtfsRtContext) SetStatus(status string) {
+	d.voContext.SetStatus(status)
+}
+
+func (d *VehicleOccupanciesGtfsRtContext) GetConnectorType() connectors.ConnectorType {
+	return connectors.Connector_GRFS_RT
 }
 
 /********* PRIVATE FUNCTIONS *********/

--- a/internal/vehicleoccupancies/contextOditi.go
+++ b/internal/vehicleoccupancies/contextOditi.go
@@ -151,7 +151,7 @@ func (d *VehicleOccupanciesOditiContext) InitContext(filesURI, externalURI url.U
 	d.voContext = &VehicleOccupanciesContext{}
 	d.voContext.ManageVehicleOccupancyStatus(occupancyActive)
 	d.voContext.SetRereshTime(loadExternalRefresh)
-
+	d.voContext.SetStatus("init")
 	err := LoadAllForVehicleOccupancies(d, navitiaURI, navitiaToken, location)
 	if err != nil {
 		logrus.Errorf("Impossible to load data at startup: %s", err)

--- a/internal/vehicleoccupancies/contextOditi.go
+++ b/internal/vehicleoccupancies/contextOditi.go
@@ -199,12 +199,28 @@ func (d *VehicleOccupanciesOditiContext) GetLastVehicleOccupanciesDataUpdate() t
 	return d.voContext.GetLastVehicleOccupanciesDataUpdate()
 }
 
+func (d *VehicleOccupanciesOditiContext) GetLastStatusUpdate() time.Time {
+	return d.voContext.GetLastStatusUpdate()
+}
+
 func (d *VehicleOccupanciesOditiContext) LoadOccupancyData() bool {
 	return d.voContext.LoadOccupancyData()
 }
 
 func (d *VehicleOccupanciesOditiContext) GetRereshTime() string {
 	return d.voContext.GetRereshTime()
+}
+
+func (d *VehicleOccupanciesOditiContext) GetStatus() string {
+	return d.voContext.GetStatus()
+}
+
+func (d *VehicleOccupanciesOditiContext) SetStatus(status string) {
+	d.voContext.SetStatus(status)
+}
+
+func (d *VehicleOccupanciesOditiContext) GetConnectorType() connectors.ConnectorType {
+	return connectors.Connector_ODITI
 }
 
 /********* PRIVATE FUNCTIONS *********/

--- a/internal/vehicleoccupancies/factory.go
+++ b/internal/vehicleoccupancies/factory.go
@@ -28,9 +28,17 @@ type IVehicleOccupancy interface {
 
 	GetLastVehicleOccupanciesDataUpdate() time.Time
 
+	GetLastStatusUpdate() time.Time
+
 	LoadOccupancyData() bool
 
 	GetRereshTime() string
+
+	GetStatus() string
+
+	SetStatus(status string)
+
+	GetConnectorType() connectors.ConnectorType
 }
 
 // Patern factory Vehicle occupancies

--- a/internal/vehiclepositions/contextGtfsRt.go
+++ b/internal/vehiclepositions/contextGtfsRt.go
@@ -93,6 +93,10 @@ func (d *GtfsRtContext) GetLastVehiclePositionsDataUpdate() time.Time {
 	return d.vehiclePositions.GetLastVehiclePositionsDataUpdate()
 }
 
+func (d *GtfsRtContext) GetLastStatusUpdate() time.Time {
+	return d.vehiclePositions.GetLastStatusUpdate()
+}
+
 func (d *GtfsRtContext) ManageVehiclePositionsStatus(vehiclePositionsActive bool) {
 	d.vehiclePositions.ManageVehiclePositionsStatus(vehiclePositionsActive)
 }
@@ -103,6 +107,14 @@ func (d *GtfsRtContext) LoadPositionsData() bool {
 
 func (d *GtfsRtContext) GetRereshTime() string {
 	return d.connector.GetFilesRefreshTime().String()
+}
+
+func (d *GtfsRtContext) GetStatus() string {
+	return d.vehiclePositions.GetStatus()
+}
+
+func (d *GtfsRtContext) SetStatus(status string) {
+	d.vehiclePositions.SetStatus(status)
 }
 
 func (d *GtfsRtContext) GetConnectorType() connectors.ConnectorType {

--- a/internal/vehiclepositions/contextGtfsRt.go
+++ b/internal/vehiclepositions/contextGtfsRt.go
@@ -72,6 +72,7 @@ func (d *GtfsRtContext) InitContext(
 	d.location = location
 	d.cleanVp = positionCleanVP
 	d.vehiclePositions.ManageVehiclePositionsStatus(reloadActive)
+	d.vehiclePositions.SetStatus("init")
 }
 
 // main loop to refresh vehicle_positions

--- a/internal/vehiclepositions/contextrennes.go
+++ b/internal/vehiclepositions/contextrennes.go
@@ -240,12 +240,24 @@ func (d *RennesContext) GetLastVehiclePositionsDataUpdate() time.Time {
 	return d.vehiclePositions.GetLastVehiclePositionsDataUpdate()
 }
 
+func (d *RennesContext) GetLastStatusUpdate() time.Time {
+	return d.vehiclePositions.GetLastStatusUpdate()
+}
+
 func (d *RennesContext) ManageVehiclePositionsStatus(vehiclePositionsActive bool) {
 	d.vehiclePositions.ManageVehiclePositionsStatus(vehiclePositionsActive)
 }
 
 func (d *RennesContext) LoadPositionsData() bool {
 	return d.vehiclePositions.LoadPositionsData()
+}
+
+func (d *RennesContext) GetStatus() string {
+	return d.vehiclePositions.GetStatus()
+}
+
+func (d *RennesContext) SetStatus(status string) {
+	d.vehiclePositions.SetStatus(status)
 }
 
 func (d *RennesContext) GetRereshTime() string {

--- a/internal/vehiclepositions/contextrennes.go
+++ b/internal/vehiclepositions/contextrennes.go
@@ -167,6 +167,7 @@ func (d *RennesContext) InitContext(
 	d.setRealTimeVehicleJourneyCode(nil)
 	d.vehiclePositions = &VehiclePositions{}
 	d.vehiclePositions.ManageVehiclePositionsStatus(reloadActive)
+	d.vehiclePositions.SetStatus("init")
 }
 
 // main loop to refresh vehicle_positions

--- a/internal/vehiclepositions/factory.go
+++ b/internal/vehiclepositions/factory.go
@@ -35,6 +35,8 @@ type IConnectors interface {
 
 	GetLastVehiclePositionsDataUpdate() time.Time
 
+	GetLastStatusUpdate() time.Time
+
 	ManageVehiclePositionsStatus(activate bool)
 
 	LoadPositionsData() bool
@@ -42,6 +44,10 @@ type IConnectors interface {
 	GetRereshTime() string
 
 	GetConnectorType() connectors.ConnectorType
+
+	GetStatus() string
+
+	SetStatus(status string)
 }
 
 // Patern factory

--- a/internal/vehiclepositions/vehiclepositions.go
+++ b/internal/vehiclepositions/vehiclepositions.go
@@ -18,7 +18,9 @@ import (
 type VehiclePositions struct {
 	vehiclePositions           map[string]*VehiclePosition
 	lastVehiclePositionsUpdate time.Time
+	lastStatusUpdate           time.Time
 	loadOccupancyData          bool
+	status                     string
 	mutex                      sync.RWMutex
 }
 
@@ -140,10 +142,29 @@ func (d *VehiclePositions) GetLastVehiclePositionsDataUpdate() time.Time {
 	return d.lastVehiclePositionsUpdate
 }
 
+func (d *VehiclePositions) GetLastStatusUpdate() time.Time {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+
+	return d.lastStatusUpdate
+}
+
 func (d *VehiclePositions) LoadPositionsData() bool {
 	d.mutex.RLock()
 	defer d.mutex.RUnlock()
 	return d.loadOccupancyData
+}
+
+func (d *VehiclePositions) GetStatus() string {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	return d.status
+}
+
+func (d *VehiclePositions) SetStatus(status string) {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	d.status = status
 }
 
 func NewVehiclePosition(sourceCode string, date time.Time, lat float32, lon float32, bearing float32,

--- a/internal/vehiclepositions/vehiclepositions.go
+++ b/internal/vehiclepositions/vehiclepositions.go
@@ -164,6 +164,7 @@ func (d *VehiclePositions) GetStatus() string {
 func (d *VehiclePositions) SetStatus(status string) {
 	d.mutex.RLock()
 	defer d.mutex.RUnlock()
+	d.lastStatusUpdate = time.Now()
 	d.status = status
 }
 


### PR DESCRIPTION
The followings are the modifications:
1. departures add in status
2. Some attributes added in each object of status
- source_status: reflects status of the external service used by the connector to feed api (values = ok/ko)
- last_status_update: latest date-time when connector was called to verify it's status
- message: Message if exists when the external service was called.  

For more details: https://navitia.atlassian.net/browse/NAV-1693