### PR TITLE
Feat manage cancelled departure in sirism

### DIFF
--- a/fixtures/data_sirism/notif_siri_lille_cancelled.xml
+++ b/fixtures/data_sirism/notif_siri_lille_cancelled.xml
@@ -1,0 +1,54 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+	<soap:Body>
+		<ns1:NotifyStopMonitoring xmlns:ns1="http://wsdl.siri.org.uk">
+			<ServiceDeliveryInfo xmlns:ns2="http://www.ifopt.org.uk/acsb" xmlns:ns3="http://www.ifopt.org.uk/ifopt" xmlns:ns4="http://datex2.eu/schema/2_0RC1/2_0" xmlns:ns5="http://www.siri.org.uk/siri" xmlns:ns6="http://wsdl.siri.org.uk/siri">
+				<ns5:ResponseTimestamp>2023-01-10T12:54:47.270+02:00</ns5:ResponseTimestamp>
+				<ns5:ProducerRef>ILEVIA</ns5:ProducerRef>
+				<ns5:ResponseMessageIdentifier>ILEVIA:ResponseMessage::2742558:LOC</ns5:ResponseMessageIdentifier>
+				<ns5:RequestMessageRef>SUBREQ</ns5:RequestMessageRef>
+			</ServiceDeliveryInfo>
+			<Notification xmlns:ns2="http://www.ifopt.org.uk/acsb" xmlns:ns3="http://www.ifopt.org.uk/ifopt" xmlns:ns4="http://datex2.eu/schema/2_0RC1/2_0" xmlns:ns5="http://www.siri.org.uk/siri" xmlns:ns6="http://wsdl.siri.org.uk/siri">
+				<ns5:StopMonitoringDelivery version="2.0:FR-IDF-2.4">
+					<ns5:ResponseTimestamp>2023-01-10T12:54:47.270+02:00</ns5:ResponseTimestamp>
+					<ns5:RequestMessageRef>SUBHOR_ILEVIA:StopPoint:BP:PRR004:LOC</ns5:RequestMessageRef>
+					<ns5:SubscriberRef>KISIO2</ns5:SubscriberRef>
+					<ns5:SubscriptionRef>SUBHOR_ILEVIA:StopPoint:BP:PRR004:LOC</ns5:SubscriptionRef>
+					<ns5:Status>true</ns5:Status>
+					<ns5:MonitoringRef>ILEVIA:StopPoint:BP:CER001:LOC</ns5:MonitoringRef>
+					<ns5:MonitoredStopVisit>
+						<ns5:RecordedAtTime>2023-01-10T12:54:47.270+02:00</ns5:RecordedAtTime>
+						<ns5:ItemIdentifier>SIRI:130754436</ns5:ItemIdentifier>
+						<ns5:MonitoringRef>ILEVIA:StopPoint:BP:CER001:LOC</ns5:MonitoringRef>
+						<ns5:MonitoredVehicleJourney>
+							<ns5:LineRef>ILEVIA:Line::L1:LOC</ns5:LineRef>
+							<ns5:FramedVehicleJourneyRef>
+								<ns5:DataFrameRef>ILEVIA:DataFrame::1.0:LOC</ns5:DataFrameRef>
+								<ns5:DatedVehicleJourneyRef>ILEVIA:VehicleJourney::18_15_142600_3_LAMJV_8:LOC</ns5:DatedVehicleJourneyRef>
+							</ns5:FramedVehicleJourneyRef>
+							<ns5:JourneyPatternRef>ILEVIA:JourneyPattern::18_NOT001_HDV018_1:LOC</ns5:JourneyPatternRef>
+							<ns5:JourneyPatternName>18_NOT001_HDV018_1</ns5:JourneyPatternName>
+							<ns5:VehicleMode>bus</ns5:VehicleMode>
+							<ns5:PublishedLineName>LIGNE 1</ns5:PublishedLineName>
+							<ns5:DirectionName>ALLER</ns5:DirectionName>
+							<ns5:OperatorRef>ILEVIA:Operator::ILEVIA:LOC</ns5:OperatorRef>
+							<ns5:DestinationRef>ILEVIA:StopPoint:BP:HDV018:LOC</ns5:DestinationRef>
+							<ns5:DestinationName>V. D'ASCQ HOTEL DE VILLE</ns5:DestinationName>
+							<ns5:Monitored>true</ns5:Monitored>
+							<ns5:MonitoredCall>
+								<ns5:StopPointRef>ILEVIA:StopPoint:BP:CER001:LOC</ns5:StopPointRef>
+								<ns5:Order>18</ns5:Order>
+								<ns5:StopPointName>LE CERF</ns5:StopPointName>
+								<ns5:VehicleAtStop>false</ns5:VehicleAtStop>
+								<ns5:DestinationDisplay>HOTEL DE VILLE</ns5:DestinationDisplay>
+								<ns5:AimedDepartureTime>2023-01-10T17:54:47.270+02:00</ns5:AimedDepartureTime>
+								<ns5:ExpectedDepartureTime>2023-01-10T17:54:47.270+02:00</ns5:ExpectedDepartureTime>
+								<ns5:DepartureStatus>Cancelled</ns5:DepartureStatus>
+							</ns5:MonitoredCall>
+						</ns5:MonitoredVehicleJourney>
+					</ns5:MonitoredStopVisit>
+				</ns5:StopMonitoringDelivery>
+			</Notification>
+			<SiriExtension xmlns:ns2="http://www.ifopt.org.uk/acsb" xmlns:ns3="http://www.ifopt.org.uk/ifopt" xmlns:ns4="http://datex2.eu/schema/2_0RC1/2_0" xmlns:ns5="http://www.siri.org.uk/siri" xmlns:ns6="http://wsdl.siri.org.uk/siri"/>
+		</ns1:NotifyStopMonitoring>
+	</soap:Body>
+</soap:Envelope>

--- a/internal/departures/sirism/departure_test.go
+++ b/internal/departures/sirism/departure_test.go
@@ -417,7 +417,6 @@ func TestLoadDeparturesFromByteArray(t *testing.T) {
                         <ns5:LineRef>ILEVIA:Line::L1:LOC</ns5:LineRef>
                         <ns5:FramedVehicleJourneyRef>
                             <ns5:DataFrameRef>ILEVIA:DataFrame::1.0:LOC</ns5:DataFrameRef>
-                            <ns5:DatedVehicleJourneyRef>ILEVIA:VehicleJourney::18_15_142600_3_LAMJV_8:LOC</ns5:DatedVehicleJourneyRef>
                         </ns5:FramedVehicleJourneyRef>
                         <ns5:JourneyPatternRef>ILEVIA:JourneyPattern::18_NOT001_HDV018_1:LOC</ns5:JourneyPatternRef>
                         <ns5:JourneyPatternName>18_NOT001_HDV018_1</ns5:JourneyPatternName>

--- a/internal/departures/sirism/departure_test.go
+++ b/internal/departures/sirism/departure_test.go
@@ -235,6 +235,18 @@ func TestExtractDeparturesFromFilePath(t *testing.T) {
 			},
 			expectedLastCancelledDeparture: nil,
 		},
+		{
+			xmlFileName:                         "notif_siri_lille_cancelled.xml",
+			expectedNumberOfUpdatedDepartures:   0,
+			expectedFirstUpdatedDeparture:       nil,
+			expectedLastUpdatedDeparture:        nil,
+			expectedNumberOfCancelledDepartures: 1,
+			expectedFirstCancelledDeparture: &CancelledDeparture{
+				Id:           ItemId("SIRI:130754436"),
+				StopPointRef: StopPointRef("CER001"),
+			},
+			expectedLastCancelledDeparture: nil,
+		},
 	}
 	for _, test := range tests {
 		uri, err := url.Parse(fmt.Sprintf("file://%s/data_sirism/%s", fixtureDir, test.xmlFileName))

--- a/internal/departures/sirism/departure_test.go
+++ b/internal/departures/sirism/departure_test.go
@@ -402,6 +402,45 @@ func TestLoadDeparturesFromByteArray(t *testing.T) {
 					</ns5:VehicleJourneyRef>
 				</ns5:MonitoredStopVisitCancellation>
 			</ns5:StopMonitoringDelivery>
+			<ns5:StopMonitoringDelivery version="2.0:FR-IDF-2.4">
+                <ns5:ResponseTimestamp>2023-01-10T12:54:47.270+02:00</ns5:ResponseTimestamp>
+                <ns5:RequestMessageRef>SUBHOR_ILEVIA:StopPoint:BP:PRR004:LOC</ns5:RequestMessageRef>
+                <ns5:SubscriberRef>KISIO2</ns5:SubscriberRef>
+                <ns5:SubscriptionRef>SUBHOR_ILEVIA:StopPoint:BP:PRR004:LOC</ns5:SubscriptionRef>
+                <ns5:Status>true</ns5:Status>
+                <ns5:MonitoringRef>ILEVIA:StopPoint:BP:CER001:LOC</ns5:MonitoringRef>
+                <ns5:MonitoredStopVisit>
+                    <ns5:RecordedAtTime>2023-01-10T12:54:47.270+02:00</ns5:RecordedAtTime>
+                    <ns5:ItemIdentifier>SIRI:130784050</ns5:ItemIdentifier>
+                    <ns5:MonitoringRef>ILEVIA:StopPoint:BP:CER001:LOC</ns5:MonitoringRef>
+                    <ns5:MonitoredVehicleJourney>
+                        <ns5:LineRef>ILEVIA:Line::L1:LOC</ns5:LineRef>
+                        <ns5:FramedVehicleJourneyRef>
+                            <ns5:DataFrameRef>ILEVIA:DataFrame::1.0:LOC</ns5:DataFrameRef>
+                            <ns5:DatedVehicleJourneyRef>ILEVIA:VehicleJourney::18_15_142600_3_LAMJV_8:LOC</ns5:DatedVehicleJourneyRef>
+                        </ns5:FramedVehicleJourneyRef>
+                        <ns5:JourneyPatternRef>ILEVIA:JourneyPattern::18_NOT001_HDV018_1:LOC</ns5:JourneyPatternRef>
+                        <ns5:JourneyPatternName>18_NOT001_HDV018_1</ns5:JourneyPatternName>
+                        <ns5:VehicleMode>bus</ns5:VehicleMode>
+                        <ns5:PublishedLineName>LIGNE 1</ns5:PublishedLineName>
+                        <ns5:DirectionName>ALLER</ns5:DirectionName>
+                        <ns5:OperatorRef>ILEVIA:Operator::ILEVIA:LOC</ns5:OperatorRef>
+                        <ns5:DestinationRef>ILEVIA:StopPoint:BP:HDV018:LOC</ns5:DestinationRef>
+                        <ns5:DestinationName>V. D'ASCQ HOTEL DE VILLE</ns5:DestinationName>
+                        <ns5:Monitored>true</ns5:Monitored>
+                        <ns5:MonitoredCall>
+                            <ns5:StopPointRef>ILEVIA:StopPoint:BP:CER001:LOC</ns5:StopPointRef>
+                            <ns5:Order>18</ns5:Order>
+                            <ns5:StopPointName>LE CERF</ns5:StopPointName>
+                            <ns5:VehicleAtStop>false</ns5:VehicleAtStop>
+                            <ns5:DestinationDisplay>HOTEL DE VILLE</ns5:DestinationDisplay>
+                            <ns5:AimedDepartureTime>2023-01-10T17:54:47.270+02:00</ns5:AimedDepartureTime>
+                            <ns5:ExpectedDepartureTime>2023-01-10T17:54:47.270+02:00</ns5:ExpectedDepartureTime>
+                            <ns5:DepartureStatus>Cancelled</ns5:DepartureStatus>
+                        </ns5:MonitoredCall>
+                    </ns5:MonitoredVehicleJourney>
+                </ns5:MonitoredStopVisit>
+            </ns5:StopMonitoringDelivery>
 		</Notification>
 		<SiriExtension
 			xmlns:ns2="http://www.ifopt.org.uk/acsb"
@@ -479,10 +518,19 @@ func TestLoadDeparturesFromByteArray(t *testing.T) {
 				Id:           ItemId("SIRI:130784051"),
 				StopPointRef: StopPointRef("CAS002"),
 			},
+			{
+				Id:           ItemId("SIRI:130784050"),
+				StopPointRef: StopPointRef("CER001"),
+			},
+
 		}
 		assert.Equal(
-			expectedCancelledDepartures,
-			getCancelledDepartures,
+			expectedCancelledDepartures[0],
+			getCancelledDepartures[0],
+		)
+		assert.Equal(
+			expectedCancelledDepartures[1],
+			getCancelledDepartures[1],
 		)
 	}
 

--- a/internal/departures/sirism/departure_test.go
+++ b/internal/departures/sirism/departure_test.go
@@ -522,7 +522,6 @@ func TestLoadDeparturesFromByteArray(t *testing.T) {
 				Id:           ItemId("SIRI:130784050"),
 				StopPointRef: StopPointRef("CER001"),
 			},
-
 		}
 		assert.Equal(
 			expectedCancelledDepartures[0],

--- a/internal/sirism/xml/xml.go
+++ b/internal/sirism/xml/xml.go
@@ -198,6 +198,7 @@ type MonitoredCall struct {
 	StopPointRef          StopPointRef `xml:"StopPointRef"`
 	AimedDepartureTime    customTime   `xml:"AimedDepartureTime"`
 	ExpectedDepartureTime *customTime  `xml:"ExpectedDepartureTime,omitempty"`
+	DepartureStatus       string       `xml:"DepartureStatus"`
 }
 
 type customTime time.Time

--- a/internal/sirism/xml/xml_test.go
+++ b/internal/sirism/xml/xml_test.go
@@ -59,6 +59,10 @@ func TestEnvelopeGetTotalNumberOfMonitoredStopVisits(t *testing.T) {
 			xmlFileName:                              "notif_siri_lille_cancellation.xml",
 			expectedTotalNumberOfMonitoredStopVisits: 0,
 		},
+		{
+			xmlFileName:                              "notif_siri_lille_cancelled.xml",
+			expectedTotalNumberOfMonitoredStopVisits: 1,
+		},
 	}
 
 	for _, test := range tests {
@@ -144,7 +148,8 @@ func TestNotificationXmlUnmarshall(t *testing.T) {
 									Space: "http://www.siri.org.uk/siri",
 									Local: "MonitoredCall",
 								},
-								StopPointRef: StopPointRef("CAS001"),
+								StopPointRef:    StopPointRef("CAS001"),
+								DepartureStatus: "onTime",
 								AimedDepartureTime: customTime(time.Date(
 									2022, time.June, 15,
 									5, 32, 0, 0,
@@ -179,7 +184,8 @@ func TestNotificationXmlUnmarshall(t *testing.T) {
 									Space: "http://www.siri.org.uk/siri",
 									Local: "MonitoredCall",
 								},
-								StopPointRef: StopPointRef("CAS001"),
+								StopPointRef:    StopPointRef("CAS001"),
+								DepartureStatus: "onTime",
 								AimedDepartureTime: customTime(time.Date(
 									2022, time.June, 15,
 									6, 2, 0, 0,
@@ -224,7 +230,8 @@ func TestNotificationXmlUnmarshall(t *testing.T) {
 									Space: "http://www.siri.org.uk/siri",
 									Local: "MonitoredCall",
 								},
-								StopPointRef: StopPointRef("CER001"),
+								StopPointRef:    StopPointRef("CER001"),
+								DepartureStatus: "onTime",
 								AimedDepartureTime: customTime(time.Date(
 									2022, time.June, 15,
 									5, 44, 25, 0,
@@ -259,7 +266,8 @@ func TestNotificationXmlUnmarshall(t *testing.T) {
 									Space: "http://www.siri.org.uk/siri",
 									Local: "MonitoredCall",
 								},
-								StopPointRef: StopPointRef("CER001"),
+								StopPointRef:    StopPointRef("CER001"),
+								DepartureStatus: "onTime",
 								AimedDepartureTime: customTime(time.Date(
 									2022, time.June, 15,
 									6, 12, 25, 0,
@@ -294,7 +302,8 @@ func TestNotificationXmlUnmarshall(t *testing.T) {
 									Space: "http://www.siri.org.uk/siri",
 									Local: "MonitoredCall",
 								},
-								StopPointRef: StopPointRef("CER001"),
+								StopPointRef:    StopPointRef("CER001"),
+								DepartureStatus: "onTime",
 								AimedDepartureTime: customTime(time.Date(
 									2022, time.June, 15,
 									6, 14, 34, 0,
@@ -329,7 +338,8 @@ func TestNotificationXmlUnmarshall(t *testing.T) {
 									Space: "http://www.siri.org.uk/siri",
 									Local: "MonitoredCall",
 								},
-								StopPointRef: StopPointRef("CER001"),
+								StopPointRef:    StopPointRef("CER001"),
+								DepartureStatus: "onTime",
 								AimedDepartureTime: customTime(time.Date(
 									2022, time.June, 15,
 									6, 44, 34, 0,
@@ -427,7 +437,8 @@ func TestMonitoredCallUnmarshalXML(t *testing.T) {
 					Space: "http://www.siri.org.uk/siri",
 					Local: "MonitoredCall",
 				},
-				StopPointRef: StopPointRef("CEN001"),
+				StopPointRef:    StopPointRef("CEN001"),
+				DepartureStatus: "onTime",
 				AimedDepartureTime: customTime(time.Date(
 					2022, time.June, 15,
 					7, 2, 0, 000_000_000,
@@ -456,7 +467,8 @@ func TestMonitoredCallUnmarshalXML(t *testing.T) {
 					Space: "http://www.siri.org.uk/siri",
 					Local: "MonitoredCall",
 				},
-				StopPointRef: StopPointRef("CEN001"),
+				StopPointRef:    StopPointRef("CEN001"),
+				DepartureStatus: "onTime",
 				AimedDepartureTime: customTime(time.Date(
 					2022, time.June, 15,
 					7, 2, 0, 000_000_000,


### PR DESCRIPTION
Before modification:
* for a notification with StopMonitoringDelivery having MonitoredStopVisitCancellation, the deaprture is deleted from the existing departures list. Keys = ItemRef and MonitoringRef

After modification:
* for a notification with StopMonitoringDelivery having MonitoredStopVisit and MonitoredStopVisit.MonitoredVehicleJourney.MonitoredCall.DepartureStatus == "Cancelled" or "cancelled" we should also delete the departure from the existing departures list. Keys = MonitoredStopVisit.ItemIdentifier and MonitoredStopVisit.MonitoringRef

Tested with @jboigkisio

For details: https://navitia.atlassian.net/browse/NAV-1676