### PR TITLE
Manage Area Id in configuration for fluctuo

### DIFF
--- a/cmd/forseti/main.go
+++ b/cmd/forseti/main.go
@@ -62,6 +62,7 @@ type Config struct {
 	FreeFloatingsType        string        `mapstructure:"free-floatings-type"`
 	FreeFloatingsUserName    string        `mapstructure:"free-floatings-username"`
 	FreeFloatingsPassword    string        `mapstructure:"free-floatings-password"`
+	FreeFloatingsAreaId      int           `mapstructure:"free-floatings-area-id"`
 
 	OccupancyFilesURIStr   string `mapstructure:"occupancy-files-uri"`
 	OccupancyFilesURI      url.URL
@@ -158,6 +159,7 @@ func GetConfig() (Config, error) {
 	pflag.String("free-floatings-type", "fluctuo", "connector type to load data source")
 	pflag.String("free-floatings-username", "", "username for getting API access tokens")
 	pflag.String("free-floatings-password", "", "password for getting API access tokens")
+	pflag.Int("free-floatings-area-id", 6, "city id for free floating source")
 
 	//Passing configurations for vehicle_occupancies
 	pflag.String("occupancy-files-uri", "", "format: [scheme:][//[userinfo@]host][/]path")
@@ -364,7 +366,7 @@ func FreeFloating(manager *manager.DataManager, config *Config, router *gin.Engi
 		var f = fluctuo.FluctuoContext{}
 
 		f.InitContext(config.FreeFloatingsURI, config.FreeFloatingsRefresh, config.FreeFloatingsToken,
-			config.ConnectionTimeout)
+			config.ConnectionTimeout, config.FreeFloatingsAreaId)
 
 		go f.RefreshFreeFloatingLoop(freeFloatingsContext)
 	}

--- a/internal/connectors/connectors.go
+++ b/internal/connectors/connectors.go
@@ -27,6 +27,7 @@ type Connector struct {
 	filesRefreshTime  time.Duration
 	wsRefreshTime     time.Duration
 	connectionTimeout time.Duration
+	areaId            int
 	mutex             sync.Mutex
 }
 
@@ -52,6 +53,18 @@ func (d *Connector) SetToken(token string) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 	d.token = token
+}
+
+func (d *Connector) GetAreaId() int {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	return d.areaId
+}
+
+func (d *Connector) SetAreaId(areaId int) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	d.areaId = areaId
 }
 
 func (d *Connector) GetHeader() string {


### PR DESCRIPTION
* For the first connector fluctuo areaId = 6 is used for the city of Paris
* To add another service fluctuo for another city the area id should be configurable.
* For more detail : https://navitia.atlassian.net/browse/NAV-1705